### PR TITLE
Fix eventNames() type incompatibility

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ interface TypedEventEmitter<Events> {
   removeListener<E extends keyof Events> (event: E, listener: Events[E]): this
 
   emit<E extends keyof Events> (event: E, ...args: Arguments<Events[E]>): boolean
-  eventNames (): (keyof Events)[]
+  eventNames (): (keyof Events | string | symbol)[]
   listeners<E extends keyof Events> (event: E): Function[]
   listenerCount<E extends keyof Events> (event: E): number
 


### PR DESCRIPTION
Sacrifice a little bit of type safety in order to be able to do `class MyEmitter extends EventEmitter implements TypedEventEmitter<MyEvents>`.

Fixes #3.