### PR TITLE
Add rawListeners field

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,7 @@ interface TypedEventEmitter<Events> {
 
   emit<E extends keyof Events> (event: E, ...args: Arguments<Events[E]>): boolean
   eventNames (): (keyof Events | string | symbol)[]
+  rawListeners<E extends keyof Events> (event: E): Function[]
   listeners<E extends keyof Events> (event: E): Function[]
   listenerCount<E extends keyof Events> (event: E): number
 


### PR DESCRIPTION
Hi! There is [`rawListeners`](https://nodejs.org/api/events.html#events_emitter_rawlisteners_eventname) field since Node.js v9.4.0. Typescript `globals.d.ts` definition:

```typescript
  rawListeners(event: string | symbol): Function[];
  listeners(event: string | symbol): Function[];
```

So I just duplicated the `listeners` field from your typings.