### PR TITLE
Install as dev-dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Code size: Zero bytes - Just the typings, no implementation. Use the default eve
 ## Installation
 
 ```sh
-$ npm install typed-emitter
+$ npm install --save-dev typed-emitter
 
 # Using yarn:
-$ yarn add typed-emitter
+$ yarn add --dev typed-emitter
 ```
 
 


### PR DESCRIPTION
Why not install `typed-emitter` as a dev-dependency? This package doesn't have any runtime code and has no effect on the production javascript build
