### PR TITLE
chore: export Arguments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-type Arguments<T> = [T] extends [(...args: infer U) => any]
+export type Arguments<T> = [T] extends [(...args: infer U) => any]
   ? U
   : [T] extends [void] ? [] : [T]
 


### PR DESCRIPTION
I find the `Arguments` type useful for dynamic event calls that require the arguments to be passed onto the listener.
I believe they should be exported as they serve as a core and useful type in the library.