### PR TITLE
Point "main" field to index.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,6 @@
     "emitter",
     "typescript",
     "interface"
-  ]
+  ],
+  "main": "./index.d.ts"
 }


### PR DESCRIPTION
<img width="663" alt="Screen Shot 2020-09-22 at 4 35 35 PM" src="https://user-images.githubusercontent.com/646125/93935749-1a7eee00-fcf3-11ea-9b53-fd83d85a479f.png">

When enforcing the `no-unresolved` rule with https://www.npmjs.com/package/eslint-plugin-import, eslint will flag this because `main` in package.json defaults to `index.js`, which doesn't exist in this repo. So I'm just explicitly defining it here to to fix it.

I understand that this is a rather specific issue with using this eslint-plugin-import, but if you can't think of any downsides, it'd be great to get this in!
