### PR TITLE
fix: stop exporting a TS file as `"main"` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,6 @@
     "typescript",
     "interface"
   ],
-  "main": "./index.d.ts"
+  "main": "./index.js",
+  "types": "./index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "typescript",
     "interface"
   ],
-  "main": "./index.js",
+  "main": "./types.js",
   "types": "./index.d.ts"
 }

--- a/types.js
+++ b/types.js
@@ -1,0 +1,1 @@
+// https://github.com/octokit/openapi-types.ts/issues/16#issuecomment-772784156


### PR DESCRIPTION
same issue as https://github.com/octokit/openapi-types.ts/pull/45 applies here and is an easy fix :)