### PR TITLE
Add explanatory comment to `eventNames()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,7 @@ interface TypedEventEmitter<Events> {
   removeListener<E extends keyof Events> (event: E, listener: Events[E]): this
 
   emit<E extends keyof Events> (event: E, ...args: Arguments<Events[E]>): boolean
+  // The sloppy `eventNames()` return type is to mitigate type incompatibilities - see #5
   eventNames (): (keyof Events | string | symbol)[]
   rawListeners<E extends keyof Events> (event: E): Function[]
   listeners<E extends keyof Events> (event: E): Function[]


### PR DESCRIPTION
Was originally introduced by #5. Added this comment to make it obvious that this is by design.

Closes #20.