### PR TITLE
fix numbers as event names

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,8 @@ export type EventMap = {
   [key: string]: (...args: any[]) => void
 }
 
+type KeyOf<T> = keyof T | `${Extract<keyof T,number>}` | (Extract<keyof T,`${number}`> extends never ? never : number);
+
 /**
  * Type-safe event emitter.
  *
@@ -19,22 +21,22 @@ export type EventMap = {
  * ```
  */
 interface TypedEventEmitter<Events extends EventMap> {
-  addListener<E extends keyof Events> (event: E, listener: Events[E]): this
-  on<E extends keyof Events> (event: E, listener: Events[E]): this
-  once<E extends keyof Events> (event: E, listener: Events[E]): this
-  prependListener<E extends keyof Events> (event: E, listener: Events[E]): this
-  prependOnceListener<E extends keyof Events> (event: E, listener: Events[E]): this
+  addListener<E extends KeyOf<Events>> (event: E, listener: Events[E]): this
+  on<E extends KeyOf<Events>> (event: E, listener: Events[E]): this
+  once<E extends KeyOf<Events>> (event: E, listener: Events[E]): this
+  prependListener<E extends KeyOf<Events>> (event: E, listener: Events[E]): this
+  prependOnceListener<E extends KeyOf<Events>> (event: E, listener: Events[E]): this
 
-  off<E extends keyof Events>(event: E, listener: Events[E]): this
-  removeAllListeners<E extends keyof Events> (event?: E): this
-  removeListener<E extends keyof Events> (event: E, listener: Events[E]): this
+  off<E extends KeyOf<Events>>(event: E, listener: Events[E]): this
+  removeAllListeners<E extends KeyOf<Events>> (event?: E): this
+  removeListener<E extends KeyOf<Events>> (event: E, listener: Events[E]): this
 
-  emit<E extends keyof Events> (event: E, ...args: Parameters<Events[E]>): boolean
+  emit<E extends KeyOf<Events>> (event: E, ...args: Parameters<Events[E]>): boolean
   // The sloppy `eventNames()` return type is to mitigate type incompatibilities - see #5
-  eventNames (): (keyof Events | string | symbol)[]
-  rawListeners<E extends keyof Events> (event: E): Events[E][]
-  listeners<E extends keyof Events> (event: E): Events[E][]
-  listenerCount<E extends keyof Events> (event: E): number
+  eventNames (): (KeyOf<Events> | string | symbol)[]
+  rawListeners<E extends KeyOf<Events>> (event: E): Events[E][]
+  listeners<E extends KeyOf<Events>> (event: E): Events[E][]
+  listenerCount<E extends KeyOf<Events>> (event: E): number
 
   getMaxListeners (): number
   setMaxListeners (maxListeners: number): this


### PR DESCRIPTION
Problem:
```ts
class Foo extends (EventEmitter as new () => TypedEmitter<{1: () => void}>) {
    constructor() {
        super();
        this.emit("1"); // error  should be no error
    }
}
```
After fix:
```ts
class Foo extends (EventEmitter as new () => TypedEmitter<{1: () => void}>) {
    constructor() {
        super();
        this.emit("1"); // no error
        this.emit(1); // no error
        // a number as event name also works in node but for some reason it is not documented like that
    }
}

class Bar extends (EventEmitter as new () => TypedEmitter<{
    "1": () => void,
}>) {
    constructor() {
        super();
        this.emit("1"); // no error
        this.emit(1); // no error
        
        // known issue:
        this.emit(3); // no error
        // I found no way to get the number from a string
        // but the arguments are typed correctly:
        this.emit(3,""); // error
    }
}
```

(redo from #33)